### PR TITLE
Allow pattern matching

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,3 +21,6 @@ Style/NumericLiterals:
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+
+Metrics/LineLength:
+  Max: 90

--- a/exe/unthread
+++ b/exe/unthread
@@ -21,13 +21,17 @@ op = OptionParser.new do |opts|
   opts.on("-tTARFILE", "--tar-file=TARFILE", "The tar file to extract") do |t|
     options[:tar_file] = t
   end
+
+  opts.on("-pPATTERN", "--pattern=PATTERN", "Extract files that match PATTERN") do |t|
+    options[:pattern] = t
+  end
 end
 
 op.parse!
 
 abort op.banner if options[:tar_file].nil? || options[:output_dir].nil?
 
-input   = Unthread::Entry.new(options.fetch(:tar_file))
+input   = Unthread::Entry.new(options.fetch(:tar_file), options[:pattern])
 dir     = options.fetch(:output_dir)
 threads = options.fetch(:threads)
 

--- a/lib/core_extension/minitar.rb
+++ b/lib/core_extension/minitar.rb
@@ -5,7 +5,7 @@ module CoreExtensions
     #
     # Returns a Hash.
     def to_hash
-      { file_name: full_name, mode: mode, content: read }
+      { file_name: full_name, mode: mode, content: read, directory: directory? }
     end
   end
 end

--- a/lib/unthread/directory_creator.rb
+++ b/lib/unthread/directory_creator.rb
@@ -31,7 +31,7 @@ module Unthread
     # Public: Adds all directories to the queue to be created.
     def create_work
       @directories.sort_by(&:size).reverse_each do |dir|
-        executor.queue { create_directory(**dir.to_hash) }
+        executor.queue { create(dir.fetch(:file_name), dir.fetch(:mode)) }
       end
     end
 
@@ -47,11 +47,11 @@ module Unthread
     #
     # dir  - String directory to create.
     # mode - Numeric directory permissions(chmod).
-    def create_directory(file_name:, mode:)
-      return if @created.include?(file_name)
+    def create(dir, mode)
+      return if @created.include?(dir)
 
-      FileUtils.mkdir_p(File.join(@output_dir, file_name), mode: mode)
-      @created.concat Unthread::ParentDirectory.find(file_name)
+      FileUtils.mkdir_p(File.join(@output_dir, dir), mode: mode)
+      @created.concat Unthread::ParentDirectory.find(dir)
     end
   end
 end

--- a/lib/unthread/entry.rb
+++ b/lib/unthread/entry.rb
@@ -1,21 +1,30 @@
 module Unthread
   # Public: Reads files and directories from a tar archive.
   class Entry
-    # Public: Array of files within an archive.
-    attr_reader :files
-
-    # Public: Array of directories within an archive.
-    attr_reader :directories
-
     # Public - Creates an instance of Entry.
     #
-    # tar - String path to the tar file to extract.
-    def initialize(tar)
-      @tar         = File.expand_path(tar)
-      @tar_reader  = Archive::Tar::Minitar::Input.new(stream_reader)
-      @files       = []
-      @directories = []
+    # tar     - String path to the tar file to extract.
+    # pattern - A regex to extract specific files and directories.
+    def initialize(tar, pattern = nil)
+      @tar        = File.expand_path(tar)
+      @tar_reader = Archive::Tar::Minitar::Input.new(stream_reader)
+      @entries    = []
+      @pattern    = pattern ? Regexp.new(pattern) : false
       read_tar
+    end
+
+    # Public: List the directories in a tar
+    #
+    # Returns Array
+    def directories
+      @entries.select { |entry| entry[:directory] }
+    end
+
+    # Public: List the files in a tar
+    #
+    # Returns Array
+    def files
+      @entries.reject { |entry| entry[:directory] }
     end
 
     private
@@ -32,12 +41,10 @@ module Unthread
     # Private: Read each entry from a tar file.
     def read_tar
       @tar_reader.each_entry do |entry|
-        hash = entry.to_hash
+        next unless entry.file? || entry.directory?
 
-        if entry.file?
-          @files << hash
-        elsif entry.directory?
-          @directories << hash
+        if !@pattern || entry.full_name.match(@pattern)
+          @entries << entry.to_hash
         end
       end
     end

--- a/lib/unthread/file_creator.rb
+++ b/lib/unthread/file_creator.rb
@@ -29,7 +29,7 @@ module Unthread
     # Public: Adds all files to the queue to be created.
     def create_work
       @files.each do |file|
-        executor.queue { create_file(**file.to_hash) }
+        executor.queue { create(file[:file_name], file[:mode], file[:content]) }
       end
     end
 
@@ -45,7 +45,7 @@ module Unthread
     # file    - String path to the file.
     # mode    - Numeric file permission(chmod).
     # content - String contents of the file.
-    def create_file(file_name:, mode:, content:)
+    def create(file_name, mode, content)
       File.open(File.join(@output_dir, file_name), "wb", perm: mode) do |io|
         io.write(content)
       end

--- a/spec/unthread/entry_spec.rb
+++ b/spec/unthread/entry_spec.rb
@@ -13,18 +13,18 @@ describe Unthread::Entry do
 
   let(:directories) do
     [
-      { file_name: "output/", mode: 493, content: nil },
-      { file_name: "output/a/", mode: 493, content: nil },
-      { file_name: "output/b/", mode: 493, content: nil },
-      { file_name: "output/c/", mode: 493, content: nil },
-      { file_name: "output/b/subdir/", mode: 493, content: nil }
+      { file_name: "output/", mode: 493, content: nil, directory: true },
+      { file_name: "output/a/", mode: 493, content: nil, directory: true },
+      { file_name: "output/b/", mode: 493, content: nil, directory: true },
+      { file_name: "output/c/", mode: 493, content: nil, directory: true },
+      { file_name: "output/b/subdir/", mode: 493, content: nil, directory: true }
     ]
   end
 
   let(:files) do
     [
-      { file_name: "output/a/0", content: "0\n", mode: 420 },
-      { file_name: "output/a/1", content: "1\n", mode: 420 }
+      { file_name: "output/a/0", content: "0\n", mode: 420, directory: false },
+      { file_name: "output/a/1", content: "1\n", mode: 420, directory: false }
     ]
   end
 
@@ -54,6 +54,27 @@ describe Unthread::Entry do
     describe "#files" do
       it "returns files" do
         expect(described_instance.files).to eql(files)
+      end
+    end
+  end
+
+  context "Patterns" do
+    let(:pattern) { "output/b" }
+
+    let(:described_instance) do
+      described_class.new(example_tar, pattern)
+    end
+
+    let(:expected_directories) do
+      [
+        { file_name: "output/b/", mode: 493, content: nil, directory: true },
+        { file_name: "output/b/subdir/", mode: 493, content: nil, directory: true }
+      ]
+    end
+
+    describe "#directories" do
+      it "returns entries that match the given pattern" do
+        expect(described_instance.directories).to eql(expected_directories)
       end
     end
   end


### PR DESCRIPTION
This will allow extraction of specific paths with a bundle file.

```bash
bundle exec exe/unthread -t spec/bundle.tar -o /tmp/output -p "^\Awp-content/(themes|plugins)"
```