### PR TITLE
Add permission support

### DIFF
--- a/exe/unthread
+++ b/exe/unthread
@@ -3,7 +3,8 @@
 require "unthread"
 require "optparse"
 
-options = { threads: 100 }
+options     = { threads: 100 }
+permissions = {}
 
 op = OptionParser.new do |opts|
   opts.banner = "Usage: #{$PROGRAM_NAME} [options]"
@@ -23,6 +24,22 @@ op = OptionParser.new do |opts|
   opts.on("-pPATTERN", "--pattern=PATTERN", "Extract files that match the ruby Regexp PATTERN") do |t|
     options[:pattern] = t
   end
+
+  opts.on("-uUSER", "--user=USER", "The unix username for chowning each file and directory") do |t|
+    permissions[:user] = t
+  end
+
+  opts.on("-gGROUP", "--group=GROUP", "The unix group for chowning each file and directory") do |t|
+    permissions[:group] = t
+  end
+
+  opts.on("--dir-mode=DIRECTORY-MODE", Integer, "The unix mode for each extracted directory") do |t|
+    permissions[:directory_mode] = t
+  end
+
+  opts.on("--file-mode=FILE-MODE", Integer, "The unix mode for each extracted file") do |t|
+    permissions[:file_mode] = t
+  end
 end
 
 op.parse!
@@ -33,5 +50,14 @@ input   = Unthread::DirectoryReader.new(options.fetch(:source_directory), option
 dir     = options.fetch(:destination_directory)
 threads = options.fetch(:threads)
 
-Unthread::DirectoryCreator.run(input.directories, dir, threads: threads)
-Unthread::FileCreator.run(input.files, dir, threads: threads)
+created_dirs  = Unthread::DirectoryCreator.run(input.directories, dir, threads: threads)
+created_files = Unthread::FileCreator.run(input.files, dir, threads: threads)
+
+unless permissions.empty?
+  permissions[:threads] = threads
+  permissions[:mode] = permissions.delete(:directory_mode)
+  Unthread::Permission.set(created_dirs, permissions)
+
+  permissions[:mode] = permissions.delete(:file_mode)
+  Unthread::Permission.set(created_files, permissions)
+end

--- a/lib/unthread.rb
+++ b/lib/unthread.rb
@@ -3,6 +3,7 @@ require "zlib"
 require "forwardable"
 
 require "unthread/version"
+require "unthread/permission"
 require "unthread/file_attribute"
 require "unthread/parent_directory"
 require "unthread/directory_reader"

--- a/lib/unthread/directory_creator.rb
+++ b/lib/unthread/directory_creator.rb
@@ -36,8 +36,11 @@ module Unthread
     end
 
     # Public: Creates all directories.
+    #
+    # Returns an Array of directories created
     def run
       executor.run
+      @directories.map { |dir| File.join(@output_dir, dir.relative_file_name) }
     end
 
     private

--- a/lib/unthread/file_creator.rb
+++ b/lib/unthread/file_creator.rb
@@ -34,8 +34,11 @@ module Unthread
     end
 
     # Public: Creates all files.
+    #
+    # Returns an array of files created
     def run
       executor.run
+      @files.map { |file| File.join(@output_dir, file.relative_file_name) }
     end
   end
 end

--- a/lib/unthread/permission.rb
+++ b/lib/unthread/permission.rb
@@ -1,0 +1,61 @@
+module Unthread
+  # Public: Sets permissions for the given files and directories.
+  class Permission
+    def self.set(files, options = {})
+      perms = new(files, options)
+      perms.create_work
+      perms.run
+    end
+
+    # Public: The thread manager for creating directories.
+    attr_reader :executor
+
+    # Public: The options given for file ownership.
+    attr_reader :options
+
+    def initialize(files, options = {})
+      @files    = files
+      @options  = options
+      @executor = Unthread::Executor.new(options.fetch(:threads, 100))
+    end
+
+    # Public: Adds all files and directories to the queue for permission changes.
+    def create_work
+      @files.each do |file|
+        executor.queue do
+          chown(file)
+          chmod(file)
+        end
+      end
+    end
+
+    # Public: Sets all permission
+    #
+    # Returun an array of files permission were set on
+    def run
+      executor.run
+      @files
+    end
+
+    # Private: Change the ownership of the given file
+    #
+    # file - The string file name.
+    def chown(file)
+      user  = options[:user]
+      group = options[:group]
+      return unless user || group
+
+      FileUtils.chown(user, group, file)
+    end
+
+    # Private: Change the permission of the given file
+    #
+    # file - The string file name.
+    def chmod(file)
+      mode = options[:mode]
+      return unless mode
+
+      FileUtils.chmod(mode, file)
+    end
+  end
+end

--- a/spec/unthread/directory_creator_spec.rb
+++ b/spec/unthread/directory_creator_spec.rb
@@ -2,7 +2,17 @@ require "spec_helper"
 
 describe Unthread::DirectoryCreator do
   context "Executor" do
-    let(:described_instance) { described_class.new([1, 2], "/tmp/output", 1) }
+    before do
+      allow(file_attribute).to receive(:size).and_return(0)
+      allow(file_attribute).to receive(:relative_file_name).and_return("file")
+    end
+
+    let(:file_attribute) { instance_double(Unthread::FileAttribute) }
+
+    let(:described_instance) do
+      described_class.new([file_attribute, file_attribute], "/tmp/output", 1)
+    end
+
     let(:executor) { described_instance.executor }
 
     describe "#create_work" do

--- a/spec/unthread/file_creator_spec.rb
+++ b/spec/unthread/file_creator_spec.rb
@@ -20,7 +20,7 @@ describe Unthread::FileCreator do
     FileUtils.touch("/tmp/output/sub/dir/3.txt")
   end
 
-  describe "#queue" do
+  describe "#create_work" do
     it "queues the creation" do
       allow(described_instance.executor).to receive(:queue)
       described_instance.create_work
@@ -31,10 +31,17 @@ describe Unthread::FileCreator do
   end
 
   describe "#run" do
-    it "executes all work in the queue" do
+    before do
       allow(described_instance.executor).to receive(:run)
+    end
+
+    it "executes all work in the queue" do
       described_instance.run
       expect(described_instance.executor).to have_received(:run)
+    end
+
+    it "returns an array of created files" do
+      expect(described_instance.run).to include(*files.map(&:file_name))
     end
   end
 

--- a/spec/unthread/permission_spec.rb
+++ b/spec/unthread/permission_spec.rb
@@ -1,0 +1,85 @@
+require "spec_helper"
+
+describe Unthread::Permission do
+  let(:files) { ["/tmp/1.txt", "/tmp/2.txt"] }
+  let(:described_instance) { described_class.new(files, {}) }
+
+  describe "#create_work" do
+    it "queues the creation" do
+      allow(described_instance.executor).to receive(:queue)
+      described_instance.create_work
+
+      expect(described_instance.executor)
+        .to have_received(:queue).exactly(files.count).times
+    end
+  end
+
+  describe "#run" do
+    before do
+      allow(described_instance.executor).to receive(:run)
+    end
+
+    it "executes all work in the queue" do
+      described_instance.run
+      expect(described_instance.executor).to have_received(:run)
+    end
+
+    it "returns an array of created files" do
+      expect(described_instance.run).to include(*files)
+    end
+  end
+
+  describe "#self.run" do
+    let(:mode) { "0777" }
+    let(:user) { "user" }
+    let(:group) { "group" }
+    let(:file) { "/tmp/1.txt" }
+
+    before do
+      allow(FileUtils).to receive(:chmod).with(mode, file)
+      allow(FileUtils).to receive(:chown).with(user, group, file)
+      allow(FileUtils).to receive(:chown).with(user, nil, file)
+      allow(FileUtils).to receive(:chown).with(nil, group, file)
+    end
+
+    context "Chmod" do
+      it "chmod the files" do
+        described_class.set([file], mode: mode)
+        expect(FileUtils).to have_received(:chmod).with(mode, file)
+      end
+
+      it "does not chmod the files" do
+        described_class.set([file])
+        expect(FileUtils).not_to have_received(:chmod).with(mode, file)
+      end
+    end
+
+    context "Chown" do
+      it "chowns the files with the user" do
+        described_class.set([file], user: user)
+        expect(FileUtils).to have_received(:chown).with(user, nil, file)
+      end
+
+      it "chowns the files with the group" do
+        described_class.set([file], group: group)
+        expect(FileUtils).to have_received(:chown).with(nil, group, file)
+      end
+
+      it "chowns the files with the user and group" do
+        described_class.set([file], user: user, group: group)
+        expect(FileUtils).to have_received(:chown).with(user, group, file)
+      end
+
+      it "does not chown the files" do
+        described_class.set([file])
+        expect(FileUtils).not_to have_received(:chown)
+      end
+    end
+
+    it "uses the number of threads specificed" do
+      allow(Unthread::Executor).to receive(:new).with(10)
+      described_class.new(files, threads: 10)
+      expect(Unthread::Executor).to have_received(:new).with(10)
+    end
+  end
+end


### PR DESCRIPTION
```
Usage: exe/unthread [options]
    -s, --source-directory=DIRECTORY The source directory to copy from
    -d, --destination-dir=DIR        Directory to copy files to
    -n, --num-threads=THREADS        Number of threads to use for extraction (Default: 100)
    -p, --pattern=PATTERN            Extract files that match the ruby Regexp PATTERN
    -u, --user=USER                  The unix username for chowning each file and directory
    -g, --group=GROUP                The unix group for chowning each file and directory
        --dir-mode=DIRECTORY-MODE    The unix mode for each extracted directory
        --file-mode=FILE-MODE        The unix mode for each extracted file
```

Example:
```
unthread -s /tmp/dir1 -d /tmp/dir2 --user=justin --group=staff --file-mode=0777 --dir-mode=0750
```

![](http://i.imgur.com/6HaBCHE.gif)